### PR TITLE
Feature: Allow create session no subdomain

### DIFF
--- a/NextLessonWidget/Edupage.swift
+++ b/NextLessonWidget/Edupage.swift
@@ -92,10 +92,14 @@ struct Edupage {
         return subject["short"]! as! String
     }
     
-    func idToClassroom(classroomId: String) -> String {
+    func idToClassroom(classroomId: String?) -> String {
+        if classroomId == nil {
+            return ""
+        }
+        
         let dbi = data!["dbi"] as! [String: Any]
         let subjects = dbi["classrooms"]! as! [String: Any]
-        let subject = subjects[classroomId]! as! [String: Any]
+        let subject = subjects[classroomId!]! as! [String: Any]
         return subject["short"]! as! String
     }
     
@@ -138,7 +142,7 @@ struct Edupage {
             let subject = idToSubject(subjectId: subjectId)
             
             let classroomIds = lesson["classroomids"]! as! [String]
-            let classroomId = classroomIds[0]
+            let classroomId = (classroomIds.count == 0) ? nil : classroomIds[0]
             let classroomNumber = idToClassroom(classroomId: classroomId)
             
             let start = lesson["starttime"]! as! String

--- a/NextLessonWidget/Edupage.swift
+++ b/NextLessonWidget/Edupage.swift
@@ -34,12 +34,15 @@ struct Edupage {
         session.sessionConfiguration.httpCookieStorage?.removeCookies(since: Date.distantPast)
     }
     
-    mutating func login(username: String, password: String, subdomain: String) async throws {
-        if subdomain == "" {
+    mutating func login(username: String, password: String, subdomain: String?) async throws {
+        
+        let loginSubdomain = (subdomain == "" || subdomain == nil) ? "login1" : subdomain!
+        
+        if (username == "" || password == "") {
             return
         }
         
-        let requestUrl = "https://\(subdomain).edupage.org/login/index.php"
+        let requestUrl = "https://\(loginSubdomain).edupage.org/login/index.php"
         print(requestUrl)
         
         let response = await session.request(requestUrl)
@@ -59,7 +62,7 @@ struct Edupage {
             "password": password
         ]
         
-        let loginRequestUrl = "https://\(subdomain).edupage.org/login/edubarLogin.php"
+        let loginRequestUrl = "https://\(loginSubdomain).edupage.org/login/edubarLogin.php"
         let loginResponse = await session.request(
             loginRequestUrl,
             method: .post,
@@ -78,6 +81,8 @@ struct Edupage {
             .replacingOccurrences(of: "\r", with: "")
         
         data = try? JSONSerialization.jsonObject(with: jsonString.data(using: .utf8)!) as? [String: Any]
+        
+        return
     }
     
     func idToSubject(subjectId: String) -> String {

--- a/NextLessonWidget/NextLessonWidget.swift
+++ b/NextLessonWidget/NextLessonWidget.swift
@@ -70,7 +70,7 @@ struct Provider: IntentTimelineProvider {
         
         var edupage = Edupage()
         let timetable: Timetable? = try! _unsafeWait {
-            if configuration.username == nil || configuration.password == nil || configuration.subdomain == nil {
+            if configuration.username == nil || configuration.password == nil {
                 completion(SimpleEntry.error(s: "Invalid credentials"))
                 
                 return nil

--- a/NextLessonWidget/NextLessonWidget.swift
+++ b/NextLessonWidget/NextLessonWidget.swift
@@ -77,11 +77,11 @@ struct Provider: IntentTimelineProvider {
             }
             
             
-            try? await edupage.login(username: configuration.username!, password: configuration.password!, subdomain: configuration.subdomain!)
+            try? await edupage.login(username: configuration.username!, password: configuration.password!, subdomain: configuration.subdomain)
             
             
             var t = await edupage.getTimetable(date: Date.now)
-            if t == nil {
+            while (t == nil) {
                 t = await edupage.getTimetable(date: Calendar.current.date(byAdding: .day, value: 1, to: Date.now)!)
             }
             


### PR DESCRIPTION
This PR allows user to create a widget without specifing `subdomain` in the widget configuration

+ fixes
- fix widget crash on Timetable Class without an classroomId